### PR TITLE
Fix binary autoload require

### DIFF
--- a/classpreloader.php
+++ b/classpreloader.php
@@ -1,6 +1,10 @@
 #! /usr/bin/env php
 <?php
 
-require_once __DIR__ . '/vendor/autoload.php';
+if (file_exists($autoloadPath = __DIR__ . '/../../autoload.php')) {
+    require_once $autoloadPath;
+} else {
+    require_once __DIR__ . '/vendor/autoload.php';
+}
 $application = new ClassPreloader\Application();
 $application->run();


### PR DESCRIPTION
I installed the lib with composer in a project where the binary folder was `bin/`, and I got an error trying to run the binary.

```
PHP Warning:  require_once(/var/www/framework-standard-edition/vendor/classpreloader/classpreloader/vendor/autoload.php): failed to open stream: No such file or directory in /var/www/framework-standard-edition/vendor/classpreloader/classpreloader/classpreloader.php on line 4
PHP Fatal error:  require_once(): Failed opening required '/var/www/framework-standard-edition/vendor/classpreloader/classpreloader/vendor/autoload.php' (include_path='.:/usr/share/php:/usr/share/pear') in /var/www/framework-standard-edition/vendor/classpreloader/classpreloader/classpreloader.php on line 4
```
