### PR TITLE
Fixed path problem in windows

### DIFF
--- a/src/ClassPreloader/Application.php
+++ b/src/ClassPreloader/Application.php
@@ -23,8 +23,8 @@ class Application extends BaseApplication
 
         // Add each command to the CLI
         foreach ($finder as $file) {
-            $filename = $file->getPathName();
-            $pos = strpos($filename, '/ClassPreloader/') + strlen('/ClassPreloader/');
+            $filename = str_replace('\\', '/', $file->getRealpath());
+            $pos = strrpos($filename, '/ClassPreloader/') + strlen('/ClassPreloader/');
             $class = __NAMESPACE__ . '\\'
                 . substr(str_replace('/', '\\', substr($filename, $pos)), 0, -4);
             $this->add(new $class());


### PR DESCRIPTION
Summary:
- `$file->getPathName()` may return a path like `C:\Somepath\To\The/Project`; so use `getRealpath` to return a normalized path.
- `str_replace` all `'\\'` into `'/'`
- `strrpos`, should we search from the reverse side? because if I am using it as standalone and the project name starts with `ClassPreloader` then the `strpos($filename, '/ClassPreloader/')` will return a wrong position.
