### PR TITLE
Use a visitor to wrap non-namespaced code in an empty namespace.

### DIFF
--- a/src/ClassPreloader/Command/PreCompileCommand.php
+++ b/src/ClassPreloader/Command/PreCompileCommand.php
@@ -4,6 +4,7 @@ namespace ClassPreloader\Command;
 
 use ClassPreloader\Config;
 use ClassPreloader\Parser\DirVisitor;
+use ClassPreloader\Parser\NamespaceWrappingVisitor;
 use ClassPreloader\Parser\NodeTraverser;
 use ClassPreloader\Parser\FileVisitor;
 use Symfony\Component\Filesystem\Filesystem;
@@ -58,6 +59,8 @@ EOF
     {
         if (!$this->traverser) {
             $this->traverser = new NodeTraverser();
+            $this->traverser->addVisitor(new NamespaceWrappingVisitor());
+
             if ($this->input->getOption('fix_dir')) {
                 $this->traverser->addVisitor(new DirVisitor($file));
             }
@@ -96,11 +99,6 @@ EOF
         // Remove the open PHP tag
         if (substr($pretty, 6) == "<?php\n") {
             $pretty = substr($pretty, 7);
-        }
-
-        // Add a wrapping namespace if needed
-        if (false === strpos($pretty, 'namespace ')) {
-            $pretty = "namespace {\n" . $pretty . "\n}\n";
         }
 
         return $pretty;

--- a/src/ClassPreloader/Parser/NamespaceWrappingVisitor.php
+++ b/src/ClassPreloader/Parser/NamespaceWrappingVisitor.php
@@ -23,6 +23,7 @@ class NamespaceWrappingVisitor extends AbstractNodeVisitor
 
         // Wrap code in empty namespace
         if ($this->namespaceDepth === 0) {
+            ++$this->namespaceDepth;
             return new \PHPParser_Node_Stmt_Namespace(
                 new \PHPParser_Node_Name(""),
                 array($node)

--- a/src/ClassPreloader/Parser/NamespaceWrappingVisitor.php
+++ b/src/ClassPreloader/Parser/NamespaceWrappingVisitor.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace ClassPreloader\Parser;
+
+/**
+ * Ensures all code is wrapped in a namespace.
+ */
+class NamespaceWrappingVisitor extends AbstractNodeVisitor
+{
+    /**
+     * @var boolean
+     */
+    protected $namespaceDepth = 0;
+
+    /**
+     * {@inheritdoc}
+     */
+    public function enterNode(\PHPParser_Node $node)
+    {
+        if ($node instanceof \PHPParser_Node_Stmt_Namespace) {
+            ++$this->namespaceDepth;
+        }
+
+        // Wrap code in empty namespace
+        if ($this->namespaceDepth === 0) {
+            return new \PHPParser_Node_Stmt_Namespace(
+                new \PHPParser_Node_Name(""),
+                array($node)
+            );
+        }
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function leaveNode(\PHPParser_Node $node) {
+        if ($node instanceof \PHPParser_Node_Stmt_Namespace) {
+            --$this->inNamespace;
+        }
+    }
+}

--- a/src/ClassPreloader/Parser/NamespaceWrappingVisitor.php
+++ b/src/ClassPreloader/Parser/NamespaceWrappingVisitor.php
@@ -35,7 +35,7 @@ class NamespaceWrappingVisitor extends AbstractNodeVisitor
      */
     public function leaveNode(\PHPParser_Node $node) {
         if ($node instanceof \PHPParser_Node_Stmt_Namespace) {
-            --$this->inNamespace;
+            --$this->namespaceDepth;
         }
     }
 }


### PR DESCRIPTION
I found that some of the classes were outputted without a namespace, causing a `PHP Fatal error:  No code may exist outside of namespace {}`. A quick fix was implemented in #7, but this ignores files with the character sequence `namespace`, regardless of its position. It may appear in a comment, for example.

I've implemented a node visitor that ensures all code is wrapped in an empty/root namespace. I didn't feel it was necessary to make this configurable, so I did not implement an additional command line option.