### PR TITLE
In some cases class is not existent, for example if you use class_exists...

### DIFF
--- a/src/ClassPreloader/ClassLoader.php
+++ b/src/ClassPreloader/ClassLoader.php
@@ -106,7 +106,19 @@ class ClassLoader
                 $files[] = $r->getFileName();
             }
             catch (\ReflectionException $e)
-            {}
+            {
+                // We ignore all exceptions related to reflection,
+                // because in some cases class can't exists. This
+                // can be if you use in your code constuctions like
+                //
+                // if (class_exists('SomeClass')) { // <-- here will trigger autoload
+                //      class SomeSuperClass extends SomeClass {
+                //      }
+                // }
+                //
+                // We ignore all problems with classes, interfaces and
+                // traits.
+            }
         }
 
         return $files;


### PR DESCRIPTION
If in your code exists construction like

```
if (class_exists('BaseFacebook'))
{
    class SuperFrameWorkClass extends BaseFacebook {}
}
```

This is usefull if you provide some basic functionality with your framework, but don't wont to require package in requires.
