### PR TITLE
Upgrade To PHP Parser 1.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -8,7 +8,7 @@
         "symfony/console": "~2.1",
         "symfony/filesystem": "~2.1",
         "symfony/finder": "~2.1",
-        "nikic/php-parser": "~0.9"
+        "nikic/php-parser": "~1.0@beta"
     },
     "require-dev":{
         "phpunit/phpunit": "~4.0"

--- a/src/Command/PreCompileCommand.php
+++ b/src/Command/PreCompileCommand.php
@@ -6,6 +6,9 @@ use ClassPreloader\Config;
 use ClassPreloader\Parser\DirVisitor;
 use ClassPreloader\Parser\NodeTraverser;
 use ClassPreloader\Parser\FileVisitor;
+use PhpParser\Lexer;
+use PhpParser\Parser;
+use PhpParser\PrettyPrinter\Standard as PrettyPrinter;
 use Symfony\Component\Filesystem\Filesystem;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
@@ -23,8 +26,8 @@ class PreCompileCommand extends Command
     public function __construct()
     {
         parent::__construct();
-        $this->printer = new \PHPParser_PrettyPrinter_Zend();
-        $this->parser = new \PHPParser_Parser(new \PHPParser_Lexer());
+        $this->printer = new PrettyPrinter();
+        $this->parser = new Parser(new Lexer());
     }
 
     /**

--- a/src/Parser/AbstractNodeVisitor.php
+++ b/src/Parser/AbstractNodeVisitor.php
@@ -2,10 +2,12 @@
 
 namespace ClassPreloader\Parser;
 
+use PhpParser\NodeVisitorAbstract;
+
 /**
  * Abstract node visitor used to track the filename
  */
-abstract class AbstractNodeVisitor extends \PHPParser_NodeVisitorAbstract
+abstract class AbstractNodeVisitor extends NodeVisitorAbstract
 {
     /**
      * @var string Current file being parsed

--- a/src/Parser/DirVisitor.php
+++ b/src/Parser/DirVisitor.php
@@ -2,15 +2,19 @@
 
 namespace ClassPreloader\Parser;
 
+use PhpParser\Node;
+use PhpParser\Node\Scalar\MagicConst\Dir;
+use PhpParser\Node\Scalar\String;
+
 /**
  * Finds all references to __DIR__ and replaces them with the actual directory
  */
 class DirVisitor extends AbstractNodeVisitor
 {
-    public function enterNode(\PHPParser_Node $node)
+    public function enterNode(Node $node)
     {
-        if ($node instanceof \PHPParser_Node_Scalar_DirConst) {
-            return new \PHPParser_Node_Scalar_String($this->getDir());
+        if ($node instanceof Dir) {
+            return new String($this->getDir());
         }
     }
 }

--- a/src/Parser/FileVisitor.php
+++ b/src/Parser/FileVisitor.php
@@ -2,15 +2,19 @@
 
 namespace ClassPreloader\Parser;
 
+use PhpParser\Node;
+use PhpParser\Node\Scalar\MagicConst\File;
+use PhpParser\Node\Scalar\String;
+
 /**
  * Finds all references to __FILE__ and replaces them with the actual file path
  */
 class FileVisitor extends AbstractNodeVisitor
 {
-    public function enterNode(\PHPParser_Node $node)
+    public function enterNode(Node $node)
     {
-        if ($node instanceof \PHPParser_Node_Scalar_FileConst) {
-            return new \PHPParser_Node_Scalar_String($this->getFilename());
+        if ($node instanceof File) {
+            return new String($this->getFilename());
         }
     }
 }

--- a/src/Parser/NodeTraverser.php
+++ b/src/Parser/NodeTraverser.php
@@ -2,10 +2,12 @@
 
 namespace ClassPreloader\Parser;
 
+use PhpParser\NodeTraverser as BaseTraverser;
+
 /**
  * Allows a filename to be set when visiting
  */
-class NodeTraverser extends \PHPParser_NodeTraverser
+class NodeTraverser extends BaseTraverser
 {
     public function traverseFile(array $nodes, $filename)
     {


### PR DESCRIPTION
This upgrades us to php parser 1.0.

~~I've bumped our version from 1.0 to 1.1 for this change. A php parser stable tag will come in 2 week's time (https://github.com/nikic/PHP-Parser/issues/125#issuecomment-53990700), so if you like this, it might be a good idea to stamp the `1.1.0` release after php parser has a stable tag.~~ **The version bump was done as part of another pull.**

It might be a good idea to stamp the `1.1.0` release after php parser has a stable tag.
