### PR TITLE
Write file atomically

### DIFF
--- a/src/Command/PreCompileCommand.php
+++ b/src/Command/PreCompileCommand.php
@@ -300,8 +300,10 @@ EOF
         // Make sure that the output dir can be used or create it
         $this->prepareOutput($outputFile);
 
-        if (!$handle = fopen($input->getOption('output'), 'w')) {
-            throw new \RuntimeException("Unable to open {$outputFile} for writing");
+        $tmpFile = $outputFile . '.tmp';
+
+        if (!$handle = fopen($tmpFile, 'w')) {
+            throw new \RuntimeException("Unable to open {$tmpFile} for writing");
         }
 
         // Write the first line of the output
@@ -323,7 +325,13 @@ EOF
         }
         fclose($handle);
 
-        $output->writeln("> Compiled loader written to {$outputFile}");
+        $output->writeln("> Compiled loader written to {$tmpFile}");
+
+        if (!rename($tmpFile, $outputFile)) {
+            throw new \RuntimeException("Unable to copy {$tmpFile} to {$outputFile} for writing");
+        }
+
+        $output->writeln("> Compiled loader copied to {$outputFile}");
         $output->writeln('- Files: '.($count - $countSkipped).'/'.$count.' (skipped: '.$countSkipped.')');
         $output->writeln('- Filesize: '.(round(filesize($outputFile) / 1024)).' kb');
     }

--- a/src/Command/PreCompileCommand.php
+++ b/src/Command/PreCompileCommand.php
@@ -300,7 +300,7 @@ EOF
         // Make sure that the output dir can be used or create it
         $this->prepareOutput($outputFile);
 
-        $tmpFile = $outputFile . '.tmp';
+        $tmpFile = $outputFile.'.tmp';
 
         if (!$handle = fopen($tmpFile, 'w')) {
             throw new \RuntimeException("Unable to open {$tmpFile} for writing");
@@ -331,7 +331,7 @@ EOF
 
             // rename() fails with PHP4 and PHP5 under Windows if the destination file exists
             unlink($outputFile);
-            if (!rename($tmpFile, $outputFile)) {            
+            if (!rename($tmpFile, $outputFile)) {
                 throw new \RuntimeException("Unable to copy {$tmpFile} to {$outputFile} for writing");
             }
         }

--- a/src/Command/PreCompileCommand.php
+++ b/src/Command/PreCompileCommand.php
@@ -326,7 +326,6 @@ EOF
         fclose($handle);
 
         if (!rename($tmpFile, $outputFile)) {
-
             // rename() fails with PHP4 and PHP5 under Windows if the destination file exists
             unlink($outputFile);
             if (!rename($tmpFile, $outputFile)) {

--- a/src/Command/PreCompileCommand.php
+++ b/src/Command/PreCompileCommand.php
@@ -325,8 +325,6 @@ EOF
         }
         fclose($handle);
 
-        $output->writeln("> Compiled loader written to {$tmpFile}");
-
         if (!rename($tmpFile, $outputFile)) {
 
             // rename() fails with PHP4 and PHP5 under Windows if the destination file exists
@@ -336,7 +334,7 @@ EOF
             }
         }
 
-        $output->writeln("> Compiled loader copied to {$outputFile}");
+        $output->writeln("> Compiled loader written to {$outputFile}");
         $output->writeln('- Files: '.($count - $countSkipped).'/'.$count.' (skipped: '.$countSkipped.')');
         $output->writeln('- Filesize: '.(round(filesize($outputFile) / 1024)).' kb');
     }

--- a/src/Command/PreCompileCommand.php
+++ b/src/Command/PreCompileCommand.php
@@ -328,7 +328,12 @@ EOF
         $output->writeln("> Compiled loader written to {$tmpFile}");
 
         if (!rename($tmpFile, $outputFile)) {
-            throw new \RuntimeException("Unable to copy {$tmpFile} to {$outputFile} for writing");
+
+            // rename() fails with PHP4 and PHP5 under Windows if the destination file exists
+            unlink($outputFile);
+            if (!rename($tmpFile, $outputFile)) {            
+                throw new \RuntimeException("Unable to copy {$tmpFile} to {$outputFile} for writing");
+            }
         }
 
         $output->writeln("> Compiled loader copied to {$outputFile}");


### PR DESCRIPTION
On my production Laravel site I get some errors while "php artisan optimize" is running because this takes a few seconds to write the file, and it writes it line by line. While it is writing the file visitors are accessing the site and Laravel loads the vendor/compiled.php file this generates, but it is only half-written.

I've changed it so it writes to a temporary file, then moves it into its final destination using PHP's rename() function.