### PR TITLE
Replace substr in getCode() to cover more cases.

### DIFF
--- a/src/ClassPreloader.php
+++ b/src/ClassPreloader.php
@@ -129,7 +129,7 @@ class ClassPreloader
         $pretty = $this->printer->prettyPrint($stmts);
 
         $pretty = preg_replace(
-            '#^(<\?php)?(/\*\*?.*?\*/)?[\s]*(declare[\s]*\([\s]*strict_types[\s]*=[\s]*1[\s]*\);)?#sm', 
+            '#^(<\?php)?(/\*\*?.*?\*/)?[\s]*(declare[\s]*\([\s]*strict_types[\s]*=[\s]*1[\s]*\);)?#s', 
             '', 
             $pretty
         );

--- a/src/ClassPreloader.php
+++ b/src/ClassPreloader.php
@@ -128,13 +128,11 @@ class ClassPreloader
         $stmts = $this->traverser->traverseFile($parsed, $file);
         $pretty = $this->printer->prettyPrint($stmts);
 
-        if (substr($pretty, 30) === '<?php declare(strict_types=1);' || substr($pretty, 30) === "<?php\ndeclare(strict_types=1);") {
-            $pretty = substr($pretty, 32);
-        } elseif (substr($pretty, 31) === "<?php\r\ndeclare(strict_types=1);") {
-            $pretty = substr($pretty, 33);
-        } elseif (substr($pretty, 5) === '<?php') {
-            $pretty = substr($pretty, 7);
-        }
+        $pretty = preg_replace(
+            '#^(<\?php)?(/\*\*?.*?\*/)?[\s]*(declare[\s]*\([\s]*strict_types[\s]*=[\s]*1[\s]*\);)?#sm', 
+            '', 
+            $pretty
+        );
 
         return $this->getCodeWrappedIntoNamespace($parsed, $pretty);
     }

--- a/src/ClassPreloader.php
+++ b/src/ClassPreloader.php
@@ -129,8 +129,8 @@ class ClassPreloader
         $pretty = $this->printer->prettyPrint($stmts);
 
         $pretty = preg_replace(
-            '#^(<\?php)?(/\*\*?.*?\*/)?[\s]*(declare[\s]*\([\s]*strict_types[\s]*=[\s]*1[\s]*\);)?#s', 
-            '', 
+            '#^(<\?php)?(/\*\*?.*?\*/)?[\s]*(declare[\s]*\([\s]*strict_types[\s]*=[\s]*1[\s]*\);)?#s',
+            '',
             $pretty
         );
 

--- a/src/ClassPreloader.php
+++ b/src/ClassPreloader.php
@@ -129,7 +129,7 @@ class ClassPreloader
         $pretty = $this->printer->prettyPrint($stmts);
 
         $pretty = preg_replace(
-            '#^(<\?php)?(/\*\*?.*?\*/)?[\s]*(declare[\s]*\([\s]*strict_types[\s]*=[\s]*1[\s]*\);)?#s',
+            '#^(<\?php)?[\s]*(/\*\*?.*?\*/)?[\s]*(declare[\s]*\([\s]*strict_types[\s]*=[\s]*1[\s]*\);)?#s',
             '',
             $pretty
         );

--- a/tests/ClassPreloaderTest.php
+++ b/tests/ClassPreloaderTest.php
@@ -1,0 +1,49 @@
+<?php
+
+use ClassPreloader\ClassPreloader;
+use ClassPreloader\Parser\NodeTraverser;
+use PhpParser\Parser;
+use PhpParser\PrettyPrinter\Standard as PrettyPrinter;
+
+class ClassPreloaderTest extends PHPUnit_Framework_TestCase
+{
+    /**
+     * This tests the correct detection and stripping of strict_types declarations while preloading files.
+     */
+    public function testStripStrictTypeDeclaration()
+    {
+        $printer = $this->getMockBuilder(PrettyPrinter::class)->setMethods(['prettyPrint']);
+        $parser = $this->getMockBuilder(Parser::class)->setMethods(['parse']);
+        $traverser = $this->getMockBuilder(NodeTraverser::class)->setMethods(['traverseFile']);
+
+        $parserMock = $parser->getMock();
+        $parserMock->expects($this->once())
+            ->method('parse')
+            ->willReturn([]);
+        $traverserMock = $traverser->getMock();
+        $traverserMock->expects($this->once())
+            ->method('traverseFile')
+            ->willReturn([]);
+        $printerMock = $printer->getMock();
+        $printerMock->expects($this->once())
+            ->method('prettyPrint')
+            ->willReturn(
+                file_get_contents(__DIR__ . '/stubs/StrictClassWithComments.php')
+            );
+
+        $classPreloader = new ClassPreloader(
+            $printerMock,
+            $parserMock,
+            $traverserMock
+        );
+
+        $code = $classPreloader->getCode(__DIR__ . '/stubs/StrictClassWithComments.php');
+
+        // $code should not have 'declare(strict_types=1)' declarations.
+        $this->assertNotRegExp(
+            '/(.*?)declare\s*\(strict_types\s*=\s*1\)(.*?)/mi',
+            $code,
+            'Generated ClassPreloader output should correctly detect and strip strict_type declare statements.'
+        );
+    }
+}

--- a/tests/ClassPreloaderTest.php
+++ b/tests/ClassPreloaderTest.php
@@ -17,7 +17,7 @@ class ClassPreloaderTest extends PHPUnit_Framework_TestCase
             ->setMethods(['prettyPrint']);
         $parser = $this->getMockBuilder(Parser::class)
             ->disableOriginalConstructor()
-            ->setMethods(['parse']);
+            ->setMethods(['parse', 'getErrors']);
         $traverser = $this->getMockBuilder(NodeTraverser::class)
             ->disableOriginalConstructor()
             ->setMethods(['traverseFile']);

--- a/tests/ClassPreloaderTest.php
+++ b/tests/ClassPreloaderTest.php
@@ -28,7 +28,7 @@ class ClassPreloaderTest extends PHPUnit_Framework_TestCase
         $printerMock->expects($this->once())
             ->method('prettyPrint')
             ->willReturn(
-                file_get_contents(__DIR__ . '/stubs/StrictClassWithComments.php')
+                file_get_contents(__DIR__.'/stubs/StrictClassWithComments.php')
             );
 
         $classPreloader = new ClassPreloader(
@@ -37,7 +37,7 @@ class ClassPreloaderTest extends PHPUnit_Framework_TestCase
             $traverserMock
         );
 
-        $code = $classPreloader->getCode(__DIR__ . '/stubs/StrictClassWithComments.php');
+        $code = $classPreloader->getCode(__DIR__.'/stubs/StrictClassWithComments.php');
 
         // $code should not have 'declare(strict_types=1)' declarations.
         $this->assertNotRegExp(

--- a/tests/ClassPreloaderTest.php
+++ b/tests/ClassPreloaderTest.php
@@ -12,9 +12,15 @@ class ClassPreloaderTest extends PHPUnit_Framework_TestCase
      */
     public function testStripStrictTypeDeclaration()
     {
-        $printer = $this->getMockBuilder(PrettyPrinter::class)->setMethods(['prettyPrint']);
-        $parser = $this->getMockBuilder(Parser::class)->setMethods(['parse']);
-        $traverser = $this->getMockBuilder(NodeTraverser::class)->setMethods(['traverseFile']);
+        $printer = $this->getMockBuilder(PrettyPrinter::class)
+            ->disableOriginalConstructor()
+            ->setMethods(['prettyPrint']);
+        $parser = $this->getMockBuilder(Parser::class)
+            ->disableOriginalConstructor()
+            ->setMethods(['parse']);
+        $traverser = $this->getMockBuilder(NodeTraverser::class)
+            ->disableOriginalConstructor()
+            ->setMethods(['traverseFile']);
 
         $parserMock = $parser->getMock();
         $parserMock->expects($this->once())

--- a/tests/stubs/StrictClassWithComments.php
+++ b/tests/stubs/StrictClassWithComments.php
@@ -1,0 +1,13 @@
+<?php
+/**
+ * This is some copyright or file comment, popular in some libraries.
+ */
+
+declare(strict_types=1);
+
+/**
+ * Not some Class comment
+ */
+class StrictClassWithComments
+{
+}

--- a/tests/stubs/StrictClassWithComments.php
+++ b/tests/stubs/StrictClassWithComments.php
@@ -2,7 +2,6 @@
 /**
  * This is some copyright or file comment, popular in some libraries.
  */
-
 declare(strict_types=1);
 
 /**

--- a/tests/stubs/StrictClassWithComments.php
+++ b/tests/stubs/StrictClassWithComments.php
@@ -6,7 +6,7 @@
 declare(strict_types=1);
 
 /**
- * Not some Class comment
+ * Not some Class comment.
  */
 class StrictClassWithComments
 {


### PR DESCRIPTION
The current replacer does not cover all cases to remove declare statements regarding 'strict_types' definitions.

Currently not covered:
* If there is more than one line break before the declare statement
* If there are arbitrary spaces within the declare statement
* If there is a comment before the declare statement

To not build the whole statemachine by ourself I decided to use a regex to tackle those problems. As this will in most cases only be ran if the boostrap needs to be regenerated we should be safe with the implied performance hit regarding the usage of regex here.

Rundown on the Regex parts:

* `^` - Match the beginning of the file only
* `(<\?php)?` - Match starting PHP Tags (if existent)
* `([\s]*/\*\*?.*?\*/[\s]*)?` - Match file comments (if existent)
* `[\s]*` - Match arbitrary number of spaces
* `(declare[\s]*\([\s]*strict_types[\s]*=[\s]*1[\s]*\);)?` - Match strict definition (if existent)

This should handle the whole pretty cleanup more gracefully regarding external/vendored codebases which may not apply to some predefined CodingStandard.