### PR TITLE
Set allow-plugins for Composer 2.2

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -32,6 +32,9 @@
         "classmap": ["tests/stubs/"]
     },
     "config": {
+        "allow-plugins": {
+            "bamarni/composer-bin-plugin": true
+        },
         "preferred-install": "dist"
     },
     "minimum-stability": "dev",


### PR DESCRIPTION
This new configuration has been introduced with Composer 2.2: https://github.com/composer/composer/releases/tag/2.2.0-RC1