### PR TITLE
Fix for PHP 8.4 warning

### DIFF
--- a/src/CodeGenerator.php
+++ b/src/CodeGenerator.php
@@ -172,7 +172,7 @@ final class CodeGenerator
      *
      * @return string
      */
-    private static function pregReplace(string $pattern, string $replacement, string $subject, int $limit = null)
+    private static function pregReplace(string $pattern, string $replacement, string $subject, ?int $limit = null)
     {
         $output = @preg_replace($pattern, $replacement, $subject, $limit === null ? -1 : $limit);
 


### PR DESCRIPTION
Fixes the following
`PHP Deprecated:  ClassPreloader\CodeGenerator::pregReplace(): Implicitly marking parameter $limit as nullable is deprecated, the explicit nullable type must be used instead`